### PR TITLE
feat: add requirePound option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Default: `false`
 Fails if story or defect numbers are not prefixed with `#` in the commit body.
 This useful if you are generating ticket links with [standard-version](https://www.npmjs.com/package/standard-version) or [semantic-release](https://www.npmjs.com/package/semantic-release)
 
+##### domain
+Type: `String`
+
+Default: `'https://rally1.rallydev.com'`
+
+Hostname for your rally instance
+
 ## Changelog
 
 See the GitHub [release history](https://github.com/bearalliance/danger-plugin-rally/releases).

--- a/README.md
+++ b/README.md
@@ -28,8 +28,21 @@ This plugin:
 - Provides links to stories and defects mentioned in commit messages, PR title, and PR description.
 - Warns if no stories or defects are found
 
+**Note:** Only works with Bitbucket server right now. More to come!
 
-Only works with Bitbucket server right now. More to come!
+## API
+### rally([options])
+
+#### options
+
+##### requirePound
+Type: `Boolean`
+
+Default: `false`
+
+Fails if story or defect numbers are not prefixed with `#` in the commit body.
+This useful if you are generating ticket links with [standard-version](https://www.npmjs.com/package/standard-version) or [semantic-release](https://www.npmjs.com/package/semantic-release)
+
 ## Changelog
 
 See the GitHub [release history](https://github.com/bearalliance/danger-plugin-rally/releases).

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,47 @@ describe('rally', () => {
     global.markdown = undefined;
   });
 
+  describe('options', () => {
+    describe('requirePound', () => {
+      describe('when story numbers are not prefixed with a #', () => {
+        beforeEach(() => {
+          global.danger = {
+            bitbucket_server: {
+              pr: { title: 'My Test Title', description: 'some description' }
+            },
+            git: {
+              commits: [{ message: 'chore: do something\ncloses US1234567' }]
+            }
+          };
+        });
+        it('fails with a message', () => {
+          rally({ requirePound: true });
+          expect(global.fail)
+            .toHaveBeenCalledWith(`The following are referenced in the commit body, but are not prefixed by \`#\`.
+- US1234567
+Tools like [standard-version](https://www.npmjs.com/package/standard-version) rely on this marker to generate links to the ticket in the \`CHANGELOG\``);
+        });
+      });
+
+      describe('when story numbers are prefixed with a #', () => {
+        beforeEach(() => {
+          global.danger = {
+            bitbucket_server: {
+              pr: { title: 'My Test Title', description: 'some description' }
+            },
+            git: {
+              commits: [{ message: 'chore: do something\ncloses #US1234567' }]
+            }
+          };
+        });
+        it('does not fail', () => {
+          rally({ requirePound: true });
+          expect(global.fail).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
   describe('When there is no rally story in the Title, body, or commit message', () => {
     beforeEach(() => {
       global.danger = {


### PR DESCRIPTION
checks for a hash symbol before each story or defect,
and fails if not present