### PR TITLE
Add conditions for identifying Rally Task references on commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ rally();
 ```
 
 This plugin:
-- Provides links to stories and defects mentioned in commit messages, PR title, and PR description.
-- Warns if no stories or defects are found
+- Provides links to stories, tasks, and defects mentioned in commit messages, PR title, and PR description.
+- Warns if no stories, tasks, or defects are found
 
 **Note:** Only works with Bitbucket server right now. More to come!
 
@@ -40,7 +40,7 @@ Type: `Boolean`
 
 Default: `false`
 
-Fails if story or defect numbers are not prefixed with `#` in the commit body.
+Fails if story, task, or defect numbers are not prefixed with `#` in the commit body.
 This useful if you are generating ticket links with [standard-version](https://www.npmjs.com/package/standard-version) or [semantic-release](https://www.npmjs.com/package/semantic-release)
 
 ##### bodyOnly
@@ -48,7 +48,7 @@ Type: `Boolean`
 
 Default: `false`
 
-Fails if story or defect numbers mentioned in the commit header, rather than the body.
+Fails if story, task, or defect numbers mentioned in the commit header, rather than the body.
 
 ##### domain
 Type: `String`


### PR DESCRIPTION
Some workflows tend to treat a Story as a larger body of work (similar to an Epic), where several components making up that Story are then divided into Tasks.  While the solution may be at reworking the Story to be broken down into several stories - there are scenarios where Tasks are used instead.  This changeset simply follows the logic for identifying User Story references and applying it for Tasks.