### PR TITLE
fix: skipping default merge commit messages

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -93,6 +93,29 @@ describe('rally', () => {
 - US1234567
 Tools like [standard-version](https://www.npmjs.com/package/standard-version) rely on this marker to generate links to the ticket in the \`CHANGELOG\``);
         });
+        it('fails with a message and skips merge commits', () => {
+          global.danger = {
+            bitbucket_server: {
+              pr: { title: 'My Test Title', description: 'some description' }
+            },
+            git: {
+              commits: [
+                {
+                  message:
+                    'Merge pull request #1234 in BearAlliance/danger-plugin-rally from ~USER/danger-plugin-rally:feature/US1234567 to staging\n* commit h1a2s3h'
+                },
+                {
+                  message: 'chore: do something\ncloses US1234567'
+                }
+              ]
+            }
+          };
+          rally({ requirePound: true });
+          expect(global.fail)
+            .toHaveBeenCalledWith(`The following are referenced in the commit body, but are not prefixed by \`#\`.
+- US1234567
+Tools like [standard-version](https://www.npmjs.com/package/standard-version) rely on this marker to generate links to the ticket in the \`CHANGELOG\``);
+        });
       });
 
       describe('when story numbers are prefixed with a #', () => {
@@ -107,6 +130,26 @@ Tools like [standard-version](https://www.npmjs.com/package/standard-version) re
           };
         });
         it('does not fail', () => {
+          rally({ requirePound: true });
+          expect(global.fail).not.toHaveBeenCalled();
+        });
+        it('does not fail and skips merge commits', () => {
+          global.danger = {
+            bitbucket_server: {
+              pr: { title: 'My Test Title', description: 'some description' }
+            },
+            git: {
+              commits: [
+                {
+                  message:
+                    'Merge pull request #1234 in BearAlliance/danger-plugin-rally from ~USER/danger-plugin-rally:feature/US1234567 to staging\n* commit h1a2s3h'
+                },
+                {
+                  message: 'chore: do something\ncloses #US1234567'
+                }
+              ]
+            }
+          };
           rally({ requirePound: true });
           expect(global.fail).not.toHaveBeenCalled();
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export declare function markdown(message: string): void;
 const rallyStoryPattern = /US\d{7}/g;
 const rallyDefectPattern = /DE\d{6}/g;
 const rallyTaskPattern = /TA\d{7}/g;
+const mergeCommitPattern = /^Merge (pull request|branch)/;
 
 export interface RallyPluginConfig {
   domain?: string;
@@ -88,8 +89,10 @@ export default function rally(config?: RallyPluginConfig) {
   const bbs = danger.bitbucket_server;
   const prDescription = bbs.pr.description;
   const prTitle = bbs.pr.title;
-
-  const commitMessages = danger.git.commits
+  const nonMergeCommits = danger.git.commits.filter(
+    commit => !commit.message.match(mergeCommitPattern)
+  );
+  const commitMessages = nonMergeCommits
     .map(commit => commit.message)
     .join('\n');
 
@@ -97,7 +100,7 @@ export default function rally(config?: RallyPluginConfig) {
     checkForPound(commitMessages);
   }
   if (bodyOnly) {
-    checkBody(danger.git.commits.map(commit => commit.message));
+    checkBody(nonMergeCommits.map(commit => commit.message));
   }
 
   const storyNumbers = (prDescription + prTitle + commitMessages).match(


### PR DESCRIPTION
Currently, merge commits are validated for whether they contain a Rally story,
defect, or task. For scenarios where the branch name contains a Rally ticket
identifier, when that branch is merged, the branch name containing the Rally
ticket identifier will show up in the merge commit message and fail
validation as it may be missing a #.  This changeset will omit merge commits
with the default merge commit message from being validated for Rally ticket
identifiers.